### PR TITLE
Impl bindings for receiver, sender

### DIFF
--- a/roc/sender-receiver_test.go
+++ b/roc/sender-receiver_test.go
@@ -1,0 +1,169 @@
+package roc
+
+import (
+	"sync"
+	"testing"
+)
+
+type testEnv struct {
+	Sender   *Sender
+	Receiver *Receiver
+	Context  *Context
+}
+
+func makeReceiverConfig() *ReceiverConfig {
+	return &ReceiverConfig{
+		FrameSampleRate:  44100,
+		FrameChannels:    ChannelSetStereo,
+		FrameEncoding:    FrameEncodingPcmFloat,
+		AutomaticTiming:  1,
+		ResamplerProfile: ResamplerDisable,
+	}
+}
+
+func makeSenderConfig() *SenderConfig {
+	return &SenderConfig{
+		FrameSampleRate:  44100,
+		FrameChannels:    ChannelSetStereo,
+		FrameEncoding:    FrameEncodingPcmFloat,
+		AutomaticTiming:  1,
+		ResamplerProfile: ResamplerDisable,
+		FecCode:          FecRs8m,
+	}
+}
+
+func newTestEnv(t *testing.T) *testEnv {
+	var (
+		err error
+		e   testEnv
+	)
+	// create context
+	e.Context, err = OpenContext(&ContextConfig{})
+	if e.Context == nil || err != nil {
+		t.Errorf("Cannot create context: %v, error: %v", e.Context, err)
+	}
+
+	// create receiver
+	e.Receiver, err = OpenReceiver(e.Context, makeReceiverConfig())
+	if e.Receiver == nil || err != nil {
+		t.Errorf("Cannot create receiver: %v, error: %v", e.Receiver, err)
+	}
+
+	// bind receiver to two ports
+	// 1)
+	sourceAddr, err := NewAddress(AfAuto, "127.0.0.1", 0)
+	if sourceAddr == nil || err != nil {
+		t.Errorf("Cannot create source address object, address object: %v, error: %v",
+			sourceAddr, err)
+	}
+	err = e.Receiver.Bind(PortAudioSource, ProtoRtpRs8mSource, sourceAddr)
+	if err != nil {
+		t.Errorf("Cannot bind receiver: %v", err)
+	}
+
+	// 2)
+	repairAddr, err := NewAddress(AfAuto, "127.0.0.1", 0)
+	if repairAddr == nil || err != nil {
+		t.Errorf("Cannot create repair address object, address object: %v, error: %v",
+			repairAddr, err)
+	}
+	err = e.Receiver.Bind(PortAudioRepair, ProtoRs8mRepair, repairAddr)
+	if err != nil {
+		t.Errorf("Cannot bind receiver: %v", err)
+	}
+
+	// create sender
+	e.Sender, err = OpenSender(e.Context, makeSenderConfig())
+	if e.Sender == nil || err != nil {
+		t.Errorf("Cannot create sender, sender: %v, error: %v", e.Sender, err)
+	}
+
+	// bind sender to a port
+	senderAddr, err := NewAddress(AfAuto, "127.0.0.1", 0)
+	if senderAddr == nil || err != nil {
+		t.Errorf("Cannot create sender address object, address object: %v, error: %v",
+			senderAddr, err)
+	}
+	err = e.Sender.Bind(senderAddr)
+	if err != nil {
+		t.Errorf("Cannot bind sender: %v", err)
+	}
+
+	// connect sender to receiver ports
+	// 1)
+	err = e.Sender.Connect(PortAudioSource, ProtoRtpRs8mSource, sourceAddr)
+	if err != nil {
+		t.Errorf("Cannot connect sender to receiver: %v", err)
+	}
+	// 2)
+	err = e.Sender.Connect(PortAudioRepair, ProtoRs8mRepair, repairAddr)
+	if err != nil {
+		t.Errorf("Cannot connect sender to receiver: %v", err)
+	}
+	return &e
+}
+
+func (e *testEnv) close(t *testing.T) {
+	err := e.Receiver.Close()
+	if err != nil {
+		t.Fail()
+	}
+	err = e.Sender.Close()
+	if err != nil {
+		t.Fail()
+	}
+	err = e.Context.Close() // remove after finalizers are done
+	if err != nil {
+		t.Fail()
+	}
+}
+
+func Test_roc_sender_write_receiver_read(t *testing.T) {
+	e := newTestEnv(t)
+	defer e.close(t)
+
+	samplesCnt := 2
+	samples := make([]float32, samplesCnt)
+	for i := 0; i < samplesCnt; i++ {
+		samples[i] = float32(i + 1)
+	}
+
+	endChan := make(chan struct{})
+	var wait sync.WaitGroup
+	wait.Add(1)
+	go func() {
+		for {
+			err := e.Sender.WriteFloats(samples)
+			if err != nil {
+				t.Fail()
+			}
+			select {
+			case <-endChan:
+				wait.Done()
+				return
+			default:
+			}
+		}
+	}()
+
+	for {
+		recFloats := make([]float32, samplesCnt)
+		err := e.Receiver.ReadFloats(recFloats)
+		if err != nil {
+			t.Fail()
+		}
+
+		nonZeroSamplesCnt := 0
+		for i := 0; i < samplesCnt; i++ {
+			if recFloats[i] != 0 {
+				nonZeroSamplesCnt++
+			}
+		}
+		if nonZeroSamplesCnt == samplesCnt {
+			break
+		}
+	}
+
+	endChan <- struct{}{}
+	wait.Wait()
+}

--- a/roc/sender.go
+++ b/roc/sender.go
@@ -2,8 +2,95 @@ package roc
 
 /*
 #include <roc/sender.h>
+int rocGoSenderWriteFloats(roc_sender* sender, float* samples, unsigned long samples_size) {
+    roc_frame frame = {(void*)samples, samples_size*sizeof(float)};
+    return roc_sender_write(sender, &frame);
+ }
 */
 import "C"
 
+import (
+	"fmt"
+)
+
 // Sender as declared in roc/sender.h:96
 type Sender C.roc_sender
+
+func OpenSender(rocContext *Context, senderConfig *SenderConfig) (*Sender, error) {
+	senderConfigC := C.struct_roc_sender_config{
+		frame_sample_rate:        (C.uint)(senderConfig.FrameSampleRate),
+		frame_channels:           (C.roc_channel_set)(senderConfig.FrameChannels),
+		frame_encoding:           (C.roc_frame_encoding)(senderConfig.FrameEncoding),
+		packet_sample_rate:       (C.uint)(senderConfig.PacketSampleRate),
+		packet_channels:          (C.roc_channel_set)(senderConfig.PacketChannels),
+		packet_encoding:          (C.roc_packet_encoding)(senderConfig.PacketEncoding),
+		packet_length:            (C.ulonglong)(senderConfig.PacketLength),
+		packet_interleaving:      (C.uint)(senderConfig.PacketInterleaving),
+		automatic_timing:         (C.uint)(senderConfig.AutomaticTiming),
+		resampler_profile:        (C.roc_resampler_profile)(senderConfig.ResamplerProfile),
+		fec_code:                 (C.roc_fec_code)(senderConfig.FecCode),
+		fec_block_source_packets: (C.uint)(senderConfig.FecBlockSourcePackets),
+		fec_block_repair_packets: (C.uint)(senderConfig.FecBlockRepairPackets),
+	}
+	sender := C.roc_sender_open((*C.roc_context)(rocContext), &senderConfigC)
+	if sender == nil {
+		return nil, ErrInvalidArgs
+	}
+	return (*Sender)(sender), nil
+}
+
+func (s *Sender) Bind(a *Address) error {
+	errCode := C.roc_sender_bind((*C.roc_sender)(s), a.raw)
+	if errCode == 0 {
+		return nil
+	}
+	if errCode < 0 {
+		return ErrInvalidArgs
+	}
+	panic(fmt.Sprintf(
+		"unexpected return code %d from roc_address_init()", errCode))
+}
+
+func (s *Sender) Connect(portType PortType, proto Protocol, address *Address) error {
+	errCode := C.roc_sender_connect(
+		(*C.roc_sender)(s),
+		(C.roc_port_type)(portType),
+		(C.roc_protocol)(proto),
+		address.raw,
+	)
+	if errCode == 0 {
+		return nil
+	}
+	if errCode < 0 {
+		return ErrInvalidArgs
+	}
+	panic(fmt.Sprintf(
+		"unexpected return code %d from roc_address_init()", errCode))
+}
+
+func (s *Sender) WriteFloats(frame []float32) error {
+	if frame == nil {
+		return ErrInvalidArgs
+	}
+	errCode := C.rocGoSenderWriteFloats((*C.roc_sender)(s), (*C.float)(&frame[0]), (C.ulong)(len(frame)))
+	if errCode == 0 {
+		return nil
+	}
+	if errCode < 0 {
+		return ErrInvalidArgs
+	}
+	panic(fmt.Sprintf(
+		"unexpected return code %d from roc_address_init()", errCode))
+}
+
+func (s *Sender) Close() error {
+	errCode := C.roc_sender_close((*C.roc_sender)(s))
+	if errCode == 0 {
+		return nil
+	}
+	if errCode < 0 {
+		return ErrInvalidArgs
+	}
+	panic(fmt.Sprintf(
+		"unexpected return code %d from roc_address_init()", errCode))
+}


### PR DESCRIPTION
We don't want to expose the low-level `frame` structure, so both receiver and
sender use functions like `ReadBytes` and `WriteBytes` that operate on []byte.

I also added a simple "integration test" that writes something with sender,
reads it with receiver and checks that what we received is not an array of 0s.
Similar smoke-test can be found
[here](https://github.com/roc-project/roc-tests/blob/master/tests/test_service_quality.cpp).

The test does not pass somehow, maybe somebody can give me a hint?