### PR TITLE
Fix macos travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
 
 install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install -y g++ pkg-config scons ragel gengetopt libuv1-dev libunwind-dev libpulse-dev libsox-dev libcpputest-dev libtool intltool autoconf automake make cmake; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install scons ragel gengetopt libuv speexdsp sox cpputest; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew list | grep -vE 'pkg-config|automake|libtool|cmake|xz|readline|openssl|sqlite' | xargs brew pin && brew install scons ragel gengetopt libuv speexdsp sox cpputest; fi
   - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/mattn/goveralls
@@ -39,4 +39,4 @@ script:
   - go get -v .
   - go test ${GOTESTFLAGS} -coverprofile profile.cov
   - ${GOPATH}/bin/golangci-lint run .
-  - ${GOPATH}/bin/goveralls -coverprofile profile.cov -service=travis-ci
+  - if [ "$TRAVIS_REPO_SLUG" = "roc-streaming/roc-go" ]; then ${GOPATH}/bin/goveralls -coverprofile profile.cov -service=travis-ci; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
 
 install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install -y g++ pkg-config scons ragel gengetopt libuv1-dev libunwind-dev libpulse-dev libsox-dev libcpputest-dev libtool intltool autoconf automake make cmake; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew list | grep -vE 'pkg-config|automake|libtool|cmake|xz|readline|openssl|sqlite' | xargs brew pin && brew install scons ragel gengetopt libuv speexdsp sox cpputest; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew unlink python@2 && brew list | grep -vE 'pkg-config|automake|libtool|cmake|xz|readline|openssl|sqlite|python' | xargs brew pin && brew install scons ragel gengetopt libuv speexdsp sox cpputest; fi
   - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/mattn/goveralls


### PR DESCRIPTION
After the last brew update, it tries to upgrade dozens of packages pre-installed on osx travis images, and fails. This patch just pins most of the pre-installed packages, except ones needed for our dependencies, to prevent them from upgrading. A similar fix was delivered to the main repo.

This PR also disables coversalls on forks, so that travis build wont fail on a forked repo.