### PR TITLE
[WIP] Use libroc obtained from pkg-config

### DIFF
--- a/roc/address.go
+++ b/roc/address.go
@@ -1,6 +1,7 @@
 package roc
 
 /*
+#cgo pkg-config: roc
 #include <roc/address.h>
 */
 import "C"

--- a/roc/config.go
+++ b/roc/config.go
@@ -1,6 +1,7 @@
 package roc
 
 /*
+#cgo pkg-config: roc
 #include "roc/config.h"
 */
 import "C"

--- a/roc/context.go
+++ b/roc/context.go
@@ -1,6 +1,7 @@
 package roc
 
 /*
+#cgo pkg-config: roc
 #include <roc/context.h>
 */
 import "C"

--- a/roc/flags.go
+++ b/roc/flags.go
@@ -1,6 +1,7 @@
 package roc
 
 /*
+#cgo pkg-config: roc
 #cgo LDFLAGS: -lroc
 */
 import "C"

--- a/roc/log.go
+++ b/roc/log.go
@@ -1,6 +1,7 @@
 package roc
 
 /*
+#cgo pkg-config: roc
 #include <roc/log.h>
 
 void rocGoLogHandlerProxy(roc_log_level level, char* component, char* message);

--- a/roc/receiver.go
+++ b/roc/receiver.go
@@ -1,6 +1,7 @@
 package roc
 
 /*
+ #cgo pkg-config: roc
  #include <roc/receiver.h>
  #include <roc/config.h>
 int rocGoReceiverReadFloats(roc_receiver* receiver, float* samples, unsigned long samples_size) {

--- a/roc/sender.go
+++ b/roc/sender.go
@@ -1,6 +1,7 @@
 package roc
 
 /*
+#cgo pkg-config: roc
 #include <roc/sender.h>
 int rocGoSenderWriteFloats(roc_sender* sender, float* samples, unsigned long samples_size) {
     roc_frame frame = {(void*)samples, samples_size*sizeof(float)};


### PR DESCRIPTION
Could not test this, as make shows me 
```
cd roc && go build .
# github.com/roc-streaming/roc-go/roc
./address.go:5:10: fatal error: roc/address.h: No such file or directory
    5 | #include <roc/address.h>
      |          ^~~~~~~~~~~~~~~
compilation terminated.
make: *** [Makefile:8: check] Error 2
```

and pkg-config cannot find headers afaik
```
➜  roc-go git:(asalle/use-pkg-config) pkg-config --cflags-only-I roc 
<empty line>
```

Contents of my roc.pc, all the files where they are supposed to be
```
➜  roc-go git:(asalle/use-pkg-config) cat /usr/lib64/pkgconfig/roc.pc
prefix=/usr
exec_prefix=${prefix}
libdir=/usr/lib64
includedir=${prefix}/include

Name: roc
Requires: libuv libunwind speexdsp
Version: 0.1.5
Description: Real-time audio streaming over the network.
URL: https://roc-streaming.org

Libs: -L${libdir} -lroc -lrt -ldl -lm -lpthread
Cflags: -I${includedir}
```