### PR TITLE
Fix coverage report

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -103,9 +103,9 @@ jobs:
 
       - name: Prepare coverage report
         if: ${{ matrix.coverage == 'yes' }}
-        uses: jandelgado/gcov2lcov-action@v1.0.5
+        uses: jandelgado/gcov2lcov-action@v1.0.9
         with:
-          workspace: roc
+          working-directory: roc
 
       - name: Send coverage report
         if: ${{ matrix.coverage == 'yes' }}
@@ -113,7 +113,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: roc/coverage.lcov
-          base-path: roc
 
   macos:
     runs-on: macos-latest


### PR DESCRIPTION
Fix usage of `jandelgado/gcov2lcov-action` and `coverallsapp/github-action`. Coverage is not working again.

Fixes #35.