### PR TITLE
Don't use pkg-config on macOS

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -80,6 +80,7 @@ jobs:
         if: ${{ matrix.build == 'yes' }}
         run: |
           cd roc
+          go list -f {{.IgnoredGoFiles}} .
           go get -v .
 
       - name: Run tests
@@ -146,6 +147,7 @@ jobs:
       - name: Build bindings
         run: |
           cd roc
+          go list -f {{.IgnoredGoFiles}} .
           go get -v .
 
       - name: Run tests

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -105,7 +105,7 @@ jobs:
         if: ${{ matrix.lint == 'yes' }}
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.50.1
+          version: v1.51.2
           working-directory: roc
 
       - name: Prepare coverage report

--- a/roc/flags.go
+++ b/roc/flags.go
@@ -1,6 +1,0 @@
-package roc
-
-/*
-#cgo pkg-config: roc
-*/
-import "C"

--- a/roc/flags_mac.go
+++ b/roc/flags_mac.go
@@ -1,0 +1,9 @@
+//go:build darwin
+// +build darwin
+
+package roc
+
+/*
+#cgo LDFLAGS: -lroc
+*/
+import "C"

--- a/roc/flags_nix.go
+++ b/roc/flags_nix.go
@@ -1,0 +1,9 @@
+//go:build aix || dragonfly || freebsd || hurd || illumos || linux || netbsd || openbsd || solaris
+// +build aix dragonfly freebsd hurd illumos linux netbsd openbsd solaris
+
+package roc
+
+/*
+#cgo pkg-config: roc
+*/
+import "C"


### PR DESCRIPTION
TLDR: This PR fixes macOS build.

----

We now use `#cgo LDFLAGS: -lroc` on macOS, and `#cgo pkg-config: roc` on any other *nix.

macOS does not have pkg-config out of the box, and it's less common there. It may be installed using brew, but I think it should not be a requirement from our side.

CI builds started randomly failing after merging my recent PR. The reason is that some (but not all) github action macos workers are lacking pkg-config.

----

Note about this build constraint:

```
//go:build aix || dragonfly || freebsd || hurd || illumos || linux || netbsd || openbsd || solaris
// +build aix dragonfly freebsd hurd illumos linux netbsd openbsd solaris
```

At first, I tried this:

```
//go:build unix && !darwin
// +build unix,!darwin
```

The first line `//go:build unix && !darwin` works well on recent Go versions. However, the second line `// +build unix,!darwin` for some reason fails to work on older go versions - the file with that constraint is just unconditionally ignored on both linux and mac. Seems it can't correctly handle `!` and `,` together.

I also tried:

```
//go:build unix && !darwin
// +build aix dragonfly freebsd hurd illumos linux netbsd openbsd solaris
```

But go fmt and go vet do not allow that: they insists that old-style and new-style constraints should define identical expressions.

----

I also added `go list -f {{.IgnoredGoFiles}} .` to CI. It prints the list of files matched by build constraints, which is useful for debugging CI failures.