### PR TITLE
[59]:.. Bindings for reuseaddr

### DIFF
--- a/roc/receiver.go
+++ b/roc/receiver.go
@@ -274,7 +274,6 @@ func (r *Receiver) SetMulticastGroup(slot Slot, iface Interface, ip string) erro
 // address, which may be useful if you're using socket activation mechanism.
 //
 // Automatically initializes slot with given index if it's used first time.
-
 func (r *Receiver) SetReuseaddr(slot Slot, iface Interface, enabled bool) error {
 	r.mu.RLock()
 	defer r.mu.RUnlock()

--- a/roc/receiver.go
+++ b/roc/receiver.go
@@ -275,7 +275,7 @@ func (r *Receiver) SetMulticastGroup(slot Slot, iface Interface, ip string) erro
 //
 // Automatically initializes slot with given index if it's used first time.
 
-func (r *Receiver) SetReuseaddr(slot Slot, iface Interface, enabled int) error {
+func (r *Receiver) SetReuseaddr(slot Slot, iface Interface, enabled bool) error {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -283,15 +283,13 @@ func (r *Receiver) SetReuseaddr(slot Slot, iface Interface, enabled int) error {
 		return errors.New("receiver is closed")
 	}
 
-	if enabled != 0 && enabled != 1 {
-		return errors.New("enabled is invalid")
-	}
+	cEnabled := go2cBool(enabled)
 
 	errCode := C.roc_receiver_set_reuseaddr(
 		r.cPtr,
 		(C.roc_slot)(slot),
 		(C.roc_interface)(iface),
-		(C.int)(enabled),
+		(C.int)(cEnabled),
 	)
 
 	if errCode != 0 {

--- a/roc/receiver.go
+++ b/roc/receiver.go
@@ -255,6 +255,51 @@ func (r *Receiver) SetMulticastGroup(slot Slot, iface Interface, ip string) erro
 	return nil
 }
 
+// Set receiver interface address reuse option.
+//
+// Optional.
+//
+// When set to true, SO_REUSEADDR is enabled for interface socket, regardless of socket
+// type, unless binding to ephemeral port (port explicitly set to zero).
+//
+// When set to false, SO_REUSEADDR is enabled only for multicast sockets, unless binding
+// to ephemeral port (port explicitly set to zero).
+//
+// By default set to false.
+//
+// For TCP-based protocols, SO_REUSEADDR allows immediate reuse of recently closed socket
+// in TIME_WAIT state, which may be useful you want to be able to restart server quickly.
+//
+// For UDP-based protocols, SO_REUSEADDR allows multiple processes to bind to the same
+// address, which may be useful if you're using socket activation mechanism.
+//
+// Automatically initializes slot with given index if it's used first time.
+
+func (r *Receiver) SetReuseaddr(slot Slot, iface Interface, enabled int) error {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if r.cPtr == nil {
+		return errors.New("receiver is closed")
+	}
+
+	if enabled != 0 && enabled != 1 {
+		return errors.New("enabled is invalid")
+	}
+
+	errCode := C.roc_receiver_set_reuseaddr(
+		r.cPtr,
+		(C.roc_slot)(slot),
+		(C.roc_interface)(iface),
+		(C.int)(enabled),
+	)
+
+	if errCode != 0 {
+		return newNativeErr("roc_receiver_set_reuseaddr()", errCode)
+	}
+	return nil
+}
+
 // Bind the receiver interface to a local endpoint.
 //
 // Checks that the endpoint is valid and supported by the interface, allocates

--- a/roc/receiver_test.go
+++ b/roc/receiver_test.go
@@ -65,7 +65,7 @@ func TestReceiver_SetReuseaddr(t *testing.T) {
 		wantErr              error
 	}{
 		{
-			name:                 "Ok",
+			name:                 "ok",
 			slot:                 SlotDefault,
 			iface:                InterfaceAudioSource,
 			receiverClosedBefore: false,
@@ -73,7 +73,7 @@ func TestReceiver_SetReuseaddr(t *testing.T) {
 			wantErr:              nil,
 		},
 		{
-			name:                 "Closed Receiver",
+			name:                 "olosed receiver",
 			slot:                 SlotDefault,
 			iface:                InterfaceAudioSource,
 			receiverClosedBefore: true,
@@ -81,7 +81,7 @@ func TestReceiver_SetReuseaddr(t *testing.T) {
 			wantErr:              errors.New("receiver is closed"),
 		},
 		{
-			name:                 "Bad Iface",
+			name:                 "bad iface",
 			slot:                 SlotDefault,
 			iface:                -1,
 			receiverClosedBefore: false,

--- a/roc/receiver_test.go
+++ b/roc/receiver_test.go
@@ -53,3 +53,27 @@ func TestReceiver_Open(t *testing.T) {
 		})
 	}
 }
+
+func TestReceiverSetReuseaddr(t *testing.T) {
+	ctx, err := OpenContext(ContextConfig{})
+	require.NoError(t, err)
+
+	receiver, err := OpenReceiver(ctx, ReceiverConfig{
+		FrameSampleRate: 44100,
+		FrameChannels:   ChannelSetStereo,
+		FrameEncoding:   FrameEncodingPcmFloat,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, receiver)
+
+	err = receiver.SetReuseaddr(SlotDefault, InterfaceAudioSource, 1)
+	if err != nil {
+		t.Errorf("expected no error, but got %v", err)
+	}
+
+	err = receiver.Close()
+	require.NoError(t, err)
+
+	err = ctx.Close()
+	require.NoError(t, err)
+}

--- a/roc/receiver_test.go
+++ b/roc/receiver_test.go
@@ -73,7 +73,7 @@ func TestReceiver_SetReuseaddr(t *testing.T) {
 			wantErr:              nil,
 		},
 		{
-			name:                 "olosed receiver",
+			name:                 "closed receiver",
 			slot:                 SlotDefault,
 			iface:                InterfaceAudioSource,
 			receiverClosedBefore: true,

--- a/roc/receiver_test.go
+++ b/roc/receiver_test.go
@@ -15,9 +15,11 @@ func TestReceiver_Open(t *testing.T) {
 		{
 			name: "ok",
 			config: ReceiverConfig{
-				FrameSampleRate: 44100,
-				FrameChannels:   ChannelSetStereo,
-				FrameEncoding:   FrameEncodingPcmFloat,
+				FrameSampleRate:  44100,
+				FrameChannels:    ChannelSetStereo,
+				FrameEncoding:    FrameEncodingPcmFloat,
+				ClockSource:      ClockInternal,
+				ResamplerProfile: ResamplerProfileDisable,
 			},
 			wantErr: nil,
 		},
@@ -59,17 +61,17 @@ func TestReceiverSetReuseaddr(t *testing.T) {
 	require.NoError(t, err)
 
 	receiver, err := OpenReceiver(ctx, ReceiverConfig{
-		FrameSampleRate: 44100,
-		FrameChannels:   ChannelSetStereo,
-		FrameEncoding:   FrameEncodingPcmFloat,
+		FrameSampleRate:  44100,
+		FrameChannels:    ChannelSetStereo,
+		FrameEncoding:    FrameEncodingPcmFloat,
+		ClockSource:      ClockInternal,
+		ResamplerProfile: ResamplerProfileDisable,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, receiver)
 
-	err = receiver.SetReuseaddr(SlotDefault, InterfaceAudioSource, 1)
-	if err != nil {
-		t.Errorf("expected no error, but got %v", err)
-	}
+	err = receiver.SetReuseaddr(SlotDefault, InterfaceAudioSource, true)
+	require.NoError(t, err)
 
 	err = receiver.Close()
 	require.NoError(t, err)

--- a/roc/sender.go
+++ b/roc/sender.go
@@ -243,8 +243,6 @@ func (s *Sender) SetOutgoingAddress(slot Slot, iface Interface, ip string) error
 // address, which may be useful if you're using socket activation mechanism.
 //
 // Automatically initializes slot with given index if it's used first time.
-//
-
 func (s *Sender) SetReuseaddr(slot Slot, iface Interface, enabled int) error {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/roc/sender.go
+++ b/roc/sender.go
@@ -243,7 +243,7 @@ func (s *Sender) SetOutgoingAddress(slot Slot, iface Interface, ip string) error
 // address, which may be useful if you're using socket activation mechanism.
 //
 // Automatically initializes slot with given index if it's used first time.
-func (s *Sender) SetReuseaddr(slot Slot, iface Interface, enabled int) error {
+func (s *Sender) SetReuseaddr(slot Slot, iface Interface, enabled bool) error {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -251,15 +251,13 @@ func (s *Sender) SetReuseaddr(slot Slot, iface Interface, enabled int) error {
 		return errors.New("sender is closed")
 	}
 
-	if enabled != 0 && enabled != 1 {
-		return errors.New("enabled is invalid")
-	}
+	cEnabled := go2cBool(enabled)
 
 	errCode := C.roc_sender_set_reuseaddr(
 		s.cPtr,
 		(C.roc_slot)(slot),
 		(C.roc_interface)(iface),
-		(C.int)(enabled),
+		(C.int)(cEnabled),
 	)
 
 	if errCode != 0 {

--- a/roc/sender.go
+++ b/roc/sender.go
@@ -224,6 +224,53 @@ func (s *Sender) SetOutgoingAddress(slot Slot, iface Interface, ip string) error
 	return nil
 }
 
+// Set sender interface address reuse option.
+//
+// Optional.
+//
+// When set to true, SO_REUSEADDR is enabled for interface socket, regardless of socket
+// type, unless binding to ephemeral port (port explicitly set to zero).
+//
+// When set to false, SO_REUSEADDR is enabled only for multicast sockets, unless binding
+// to ephemeral port (port explicitly set to zero).
+//
+// By default set to false.
+//
+// For TCP-based protocols, SO_REUSEADDR allows immediate reuse of recently closed socket
+// in TIME_WAIT state, which may be useful you want to be able to restart server quickly.
+//
+// For UDP-based protocols, SO_REUSEADDR allows multiple processes to bind to the same
+// address, which may be useful if you're using socket activation mechanism.
+//
+// Automatically initializes slot with given index if it's used first time.
+//
+
+func (s *Sender) SetReuseaddr(slot Slot, iface Interface, enabled int) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.cPtr == nil {
+		return errors.New("sender is closed")
+	}
+
+	if enabled != 0 && enabled != 1 {
+		return errors.New("enabled is invalid")
+	}
+
+	errCode := C.roc_sender_set_reuseaddr(
+		s.cPtr,
+		(C.roc_slot)(slot),
+		(C.roc_interface)(iface),
+		(C.int)(enabled),
+	)
+
+	if errCode != 0 {
+		return newNativeErr("roc_sender_set_reuseaddr()", errCode)
+	}
+
+	return nil
+}
+
 // Connect the sender interface to a remote receiver endpoint.
 //
 // Checks that the endpoint is valid and supported by the interface, allocates

--- a/roc/sender_receiver_test.go
+++ b/roc/sender_receiver_test.go
@@ -92,6 +92,16 @@ func newTestEnv(t *testing.T) *testEnv {
 	return &e
 }
 
+func TestSenderSetReuseaddr(t *testing.T) {
+	e := newTestEnv(t)
+	defer e.close(t)
+
+	err := e.Sender.SetReuseaddr(SlotDefault, InterfaceAudioRepair, 1)
+	if err != nil {
+		t.Errorf("expected no error, but got %v", err)
+	}
+}
+
 func (e *testEnv) close(t *testing.T) {
 	err := e.Receiver.Close()
 	if err != nil {

--- a/roc/sender_receiver_test.go
+++ b/roc/sender_receiver_test.go
@@ -92,16 +92,6 @@ func newTestEnv(t *testing.T) *testEnv {
 	return &e
 }
 
-func TestSenderSetReuseaddr(t *testing.T) {
-	e := newTestEnv(t)
-	defer e.close(t)
-
-	err := e.Sender.SetReuseaddr(SlotDefault, InterfaceAudioRepair, 1)
-	if err != nil {
-		t.Errorf("expected no error, but got %v", err)
-	}
-}
-
 func (e *testEnv) close(t *testing.T) {
 	err := e.Receiver.Close()
 	if err != nil {

--- a/roc/sender_test.go
+++ b/roc/sender_test.go
@@ -65,7 +65,7 @@ func TestSender_SetReuseaddr(t *testing.T) {
 		wantErr            error
 	}{
 		{
-			name:               "Ok",
+			name:               "ok",
 			slot:               SlotDefault,
 			iface:              InterfaceAudioSource,
 			senderClosedBefore: false,
@@ -73,7 +73,7 @@ func TestSender_SetReuseaddr(t *testing.T) {
 			wantErr:            nil,
 		},
 		{
-			name:               "Closed Sender",
+			name:               "closed sender",
 			slot:               SlotDefault,
 			iface:              InterfaceAudioSource,
 			senderClosedBefore: true,
@@ -81,7 +81,7 @@ func TestSender_SetReuseaddr(t *testing.T) {
 			wantErr:            errors.New("sender is closed"),
 		},
 		{
-			name:               "Bad Iface",
+			name:               "bad iface",
 			slot:               SlotDefault,
 			iface:              -1,
 			senderClosedBefore: false,

--- a/roc/sender_test.go
+++ b/roc/sender_test.go
@@ -1,0 +1,77 @@
+package roc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSender_Open(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  SenderConfig
+		wantErr error
+	}{
+		{
+			name: "ok",
+			config: SenderConfig{
+				FrameSampleRate: 44100,
+				FrameChannels:   ChannelSetStereo,
+				FrameEncoding:   FrameEncodingPcmFloat,
+			},
+			wantErr: nil,
+		},
+		{
+			name:    "invalid config",
+			config:  SenderConfig{},
+			wantErr: newNativeErr("roc_sender_open()", -1),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, err := OpenContext(ContextConfig{})
+
+			require.NoError(t, err)
+			require.NotNil(t, ctx)
+
+			sender, err := OpenSender(ctx, tt.config)
+
+			if tt.wantErr == nil {
+				require.NoError(t, err)
+				require.NotNil(t, sender)
+
+				err = sender.Close()
+				require.NoError(t, err)
+			} else {
+				require.Equal(t, tt.wantErr, err)
+				require.Nil(t, sender)
+			}
+
+			err = ctx.Close()
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestSenderSetReuseaddr(t *testing.T) {
+	ctx, err := OpenContext(ContextConfig{})
+	require.NoError(t, err)
+
+	sender, err := OpenSender(ctx, SenderConfig{
+		FrameSampleRate: 44100,
+		FrameChannels:   ChannelSetStereo,
+		FrameEncoding:   FrameEncodingPcmFloat,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, sender)
+
+	err = sender.SetReuseaddr(SlotDefault, InterfaceAudioSource, true)
+	require.NoError(t, err)
+
+	err = sender.Close()
+	require.NoError(t, err)
+
+	err = ctx.Close()
+	require.NoError(t, err)
+}


### PR DESCRIPTION
PR for #59 
Implemented:
- [x] binding for `roc_receiver_set_reuseaddr`
- [x] binding for `roc_sender_set_reuseaddr`
- [x] test for `sender.SetReuseaddr()`
- [x] test for `receiver.SetReuseaddr()`