### PR TITLE
Improvements in log tests

### DIFF
--- a/roc/log_test.go
+++ b/roc/log_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -127,14 +128,14 @@ func TestLog_Func(t *testing.T) {
 
 	select {
 	case msg := <-ch:
-		require.Equal(t, LogTrace, msg.Level, "Expected log level to be trace")
-		require.NotEmpty(t, msg.Module)
-		require.NotEmpty(t, msg.File)
-		require.NotEmpty(t, msg.Line)
-		require.NotEmpty(t, msg.Time)
-		require.NotEmpty(t, msg.Pid)
-		require.NotEmpty(t, msg.Tid)
-		require.NotEmpty(t, msg.Text)
+		assert.Equal(t, LogTrace, msg.Level, "Expected log level to be trace")
+		assert.NotEmpty(t, msg.Module)
+		assert.NotEmpty(t, msg.File)
+		assert.NotEmpty(t, msg.Line)
+		assert.NotEmpty(t, msg.Time)
+		assert.NotEmpty(t, msg.Pid)
+		assert.NotEmpty(t, msg.Tid)
+		assert.NotEmpty(t, msg.Text)
 	case <-time.After(time.Minute):
 		t.Fatal("expected logs, didn't get them before timeout")
 	}

--- a/roc/log_test.go
+++ b/roc/log_test.go
@@ -74,7 +74,8 @@ func TestLog_Default(t *testing.T) {
 
 			tt.setupFn()
 
-			ctx, _ := OpenContext(ContextConfig{})
+			ctx, err := OpenContext(ContextConfig{})
+			require.NoError(t, err)
 			ctx.Close()
 
 			if tw.waitAny() == "" {
@@ -94,7 +95,8 @@ func TestLog_Interface(t *testing.T) {
 	SetLogger(logger)
 	defer SetLogger(nil)
 
-	ctx, _ := OpenContext(ContextConfig{})
+	ctx, err := OpenContext(ContextConfig{})
+	require.NoError(t, err)
 	ctx.Close()
 
 	if tw.waitAny() == "" {
@@ -119,7 +121,10 @@ func TestLog_Func(t *testing.T) {
 	})
 	defer SetLoggerFunc(nil)
 
-	ctx, _ := OpenContext(ContextConfig{})
+	ctx, err := OpenContext(ContextConfig{})
+	require.NoError(t, err)
+	ctx.Close()
+
 	select {
 	case msg := <-ch:
 		require.Equal(t, LogTrace, msg.Level, "Expected log level to be trace")
@@ -133,7 +138,6 @@ func TestLog_Func(t *testing.T) {
 	case <-time.After(time.Minute):
 		t.Fatal("expected logs, didn't get them before timeout")
 	}
-	ctx.Close()
 }
 
 func TestLog_Levels(t *testing.T) {

--- a/roc/log_test.go
+++ b/roc/log_test.go
@@ -75,6 +75,24 @@ func TestLog_Default(t *testing.T) {
 	}
 }
 
+func TestLog_Interface(t *testing.T) {
+	SetLogLevel(LogDebug)
+	defer SetLogLevel(defaultLogLevel)
+
+	tw := makeTestWriter()
+	logger := log.New(&tw, "", log.Lshortfile)
+
+	SetLogger(logger)
+	defer SetLogger(nil)
+
+	ctx, _ := OpenContext(ContextConfig{})
+	ctx.Close()
+
+	if tw.wait() == "" {
+		t.Fatal("expected logs, didn't get them before timeout")
+	}
+}
+
 func TestLog_Func(t *testing.T) {
 	SetLogLevel(LogTrace)
 	defer SetLogLevel(defaultLogLevel)
@@ -107,22 +125,4 @@ func TestLog_Func(t *testing.T) {
 		t.Fatal("expected logs, didn't get them before timeout")
 	}
 	ctx.Close()
-}
-
-func TestLog_Interface(t *testing.T) {
-	SetLogLevel(LogDebug)
-	defer SetLogLevel(defaultLogLevel)
-
-	tw := makeTestWriter()
-	logger := log.New(&tw, "", log.Lshortfile)
-
-	SetLogger(logger)
-	defer SetLogger(nil)
-
-	ctx, _ := OpenContext(ContextConfig{})
-	ctx.Close()
-
-	if tw.wait() == "" {
-		t.Fatal("expected logs, didn't get them before timeout")
-	}
 }

--- a/roc/log_test.go
+++ b/roc/log_test.go
@@ -76,24 +76,6 @@ func TestLog_Default(t *testing.T) {
 }
 
 func TestLog_Func(t *testing.T) {
-	SetLogLevel(LogDebug)
-	defer SetLogLevel(defaultLogLevel)
-
-	tw := makeTestWriter()
-	SetLoggerFunc(func(msg LogMessage) {
-		_, _ = tw.Write([]byte(msg.Module + ":" + msg.Text))
-	})
-	defer SetLoggerFunc(nil)
-
-	ctx, _ := OpenContext(ContextConfig{})
-	ctx.Close()
-
-	if tw.wait() == "" {
-		t.Fatal("expected logs, didn't get them before timeout")
-	}
-}
-
-func TestLog_Message(t *testing.T) {
 	SetLogLevel(LogTrace)
 	defer SetLogLevel(defaultLogLevel)
 


### PR DESCRIPTION
This PR has several commits, each one with one improvement:

* recently added TestLog_Message is superior to TestLog_Func, so remove TestLog_Func
* add new test TestLog_Levels; it iterates over all levels and checks that for each one we can receive a message and it will contain correctly formatted level
* check that there are no unexpected errors, instead of ignoring them
* in TestLog_Func, use assert instead of require, so that if one check fails, we can see whether other checks also fail or not