### PR TITLE
Fix race in tests

### DIFF
--- a/roc/log_test.go
+++ b/roc/log_test.go
@@ -110,7 +110,6 @@ func TestLog_Func(t *testing.T) {
 	defer SetLogLevel(defaultLogLevel)
 
 	ch := make(chan LogMessage, 1)
-	defer close(ch)
 
 	SetLoggerFunc(func(msg LogMessage) {
 		if msg.Level == LogTrace {


### PR DESCRIPTION
This PR fixes failing build: https://github.com/roc-streaming/roc-go/actions/runs/4772204204

In TestLog_Func, channel can be sometimes closed before background func stop writing to it. We can just keep channel open.