### PR TITLE
Issue 85: Use time.Time for encoding LogMessage.Time instead of uint64

### DIFF
--- a/roc/log.go
+++ b/roc/log.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log"
 	"sync/atomic"
+	"time"
 )
 
 // LogLevel defines the logging verbosity.
@@ -49,8 +50,8 @@ type LogMessage struct {
 	// Line number in the source code file.
 	Line int
 
-	// Message timestamp, nanoseconds since Unix epoch.
-	Time uint64
+	// Message timestamp, unix time at which message was logged
+	Time time.Time
 
 	// Platform-specific process ID.
 	Pid uint64
@@ -154,7 +155,7 @@ var (
 func rocGoLogHandler(cMessage *C.roc_log_message) {
 	message := LogMessage{
 		Level: LogLevel(cMessage.level),
-		Time:  uint64(cMessage.time),
+		Time:  time.Unix(int64(cMessage.time), 0),
 		Pid:   uint64(cMessage.pid),
 		Tid:   uint64(cMessage.tid),
 	}

--- a/roc/log_test.go
+++ b/roc/log_test.go
@@ -131,7 +131,7 @@ func TestLog_Func(t *testing.T) {
 		assert.NotEmpty(t, msg.Module)
 		assert.NotEmpty(t, msg.File)
 		assert.NotEmpty(t, msg.Line)
-		assert.NotEmpty(t, msg.Time)
+		assert.False(t,msg.Time.IsZero())
 		assert.NotEmpty(t, msg.Pid)
 		assert.NotEmpty(t, msg.Tid)
 		assert.NotEmpty(t, msg.Text)

--- a/roc/receiver.go
+++ b/roc/receiver.go
@@ -359,7 +359,11 @@ func (r *Receiver) Bind(slot Slot, iface Interface, endpoint *Endpoint) error {
 		return newNativeErr("roc_receiver_bind()", errCode)
 	}
 
-	return endpoint.fromC(cEndp)
+	if err := endpoint.fromC(cEndp); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Read samples from the receiver.

--- a/roc/receiver.go
+++ b/roc/receiver.go
@@ -359,11 +359,7 @@ func (r *Receiver) Bind(slot Slot, iface Interface, endpoint *Endpoint) error {
 		return newNativeErr("roc_receiver_bind()", errCode)
 	}
 
-	if err := endpoint.fromC(cEndp); err != nil {
-		return err
-	}
-
-	return nil
+	return endpoint.fromC(cEndp)
 }
 
 // Read samples from the receiver.


### PR DESCRIPTION
- PR for #85 

- CHANGED the LogMeesage.Time encoding from uint64 to time.Time and And adjusted the testcases to check if time is not zero

- Removed the redudant error check in reciver.go as linter suggested