### PR TITLE
Tag release script

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,6 +19,10 @@ on:
   schedule:
     - cron: '0 0 * * 1'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   linux:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -202,16 +202,25 @@ make fmt
 
 ## Release
 
-To release new version:
+To release a new version:
 
-*	```
-	./tag.py --push <remote> <version>
-	e.g.
-	./tag.py --push origin 1.2.3
-	```
-	Or use **tag.py** without **--push** to only create a tag locally. And then push it manually.
-* Wait until CI completes
-* Edit GitHub release created by CI and publish it
+ * Create git tag
+ 
+    ```
+    ./tag.py --push <remote> <version>
+    ```
+    
+    e.g.
+    
+    ```
+    ./tag.py --push origin 1.2.3
+    ```
+    
+    Or use **tag.py** without **--push** to only create a tag locally, and then push it manually.
+
+* Wait until "Release" CI job completes and creates GitHub release draft.
+
+* Edit GitHub release created by CI and publish it.
 
 ## Authors
 

--- a/README.md
+++ b/README.md
@@ -200,6 +200,19 @@ Format code:
 make fmt
 ```
 
+## Release
+
+To release new version:
+
+*	```
+	./tag.py --push <remote> <version>
+	e.g.
+	./tag.py --push origin 1.2.3
+	```
+	Or use **tag.py** without **--push** to only create a tag locally. And then push it manually.
+* Wait until CI completes
+* Edit GitHub release created by CI and publish it
+
 ## Authors
 
 See [here](https://github.com/roc-streaming/roc-go/graphs/contributors).

--- a/roc/config.go
+++ b/roc/config.go
@@ -471,7 +471,7 @@ type ReceiverConfig struct {
 	// Target latency, in nanoseconds.
 	// The session will not start playing until it accumulates the requested latency.
 	// Then, if resampler is enabled, the session will adjust its clock to keep actual
-	// latency as close as close as possible to the target latency.
+	// latency as close as possible to the target latency.
 	// If zero, default value is used.
 	TargetLatency uint64
 

--- a/tag.py
+++ b/tag.py
@@ -3,9 +3,11 @@ import argparse
 import os
 import re
 import subprocess
+import fileinput
+import sys
 
 def check_version_format(version):
-    pattern = re.compile(r'^\d+\.\d+\.\d+$')
+    pattern = re.compile(r'^v?\d+\.\d+\.\d+$')
     return pattern.match(version) is not None
 
 def check_tag_exists(tag):
@@ -16,43 +18,47 @@ def check_tag_exists(tag):
         return False
 
 def write_version(version):
-    with open('roc/version.go', 'r') as f:
-        lines = f.readlines()
+    print(f'Updating version in roc/version.go to {version}')
+    version_line = re.compile(r'\bbindingsVersion\s*=\s*".*"')
+    with fileinput.FileInput('roc/version.go', inplace=True) as f:
+        for line in f:
+            print(version_line.sub(f'bindingsVersion = "{version}"', line), end='')
 
-    with open('roc/version.go', 'w') as f:
-        for line in lines:
-            if line.startswith('var bindingsVersion ='):
-                line = f'var bindingsVersion = "{version}"\n'
-            f.write(line)
+def run_command(args):
+    print(f'Running command: {" ".join(args)}')
+    subprocess.check_call(args)
 
 def commit_change(version):
-    subprocess.check_call(['git', 'add', 'roc/version.go'])
-    subprocess.check_call(['git', 'commit', '-m', f'Release {version}'])
+    run_command(['git', 'add', 'roc/version.go'])
+    run_command(['git', 'commit', '-m', f'Release {version}'])
 
 def create_tag(tag):
-    subprocess.check_call(['git', 'tag', tag])
+    run_command(['git', 'tag', tag])
 
 def push_change(remote, tag):
-    subprocess.check_call(['git', 'push', remote, 'HEAD'])
-    subprocess.check_call(['git', 'push', remote, tag])
+    run_command(['git', 'push', remote, 'HEAD'])
+    run_command(['git', 'push', remote, tag])
 
 def main():
+    os.chdir(os.path.dirname(os.path.realpath(__file__)))
+
     parser = argparse.ArgumentParser()
     parser.add_argument('--push', required=False, help='remote to push')
     parser.add_argument('version', help='version to release')
     args = parser.parse_args()
 
     version = args.version
+    if not check_version_format(version):
+        print(f'Error: version "{version}" is not in correct format. Correct format is "x.y.z" or "vx.y.z"', file=sys.stderr)
+        sys.exit(1)
+
+    version = version.lstrip("v")
     remote = args.push
     tag = f'v{version}'
 
-    if not check_version_format(version):
-        print(f'Error: version "{version}" is not in correct format. Correct format is "x.y.z"')
-        return
-
     if check_tag_exists(tag):
-        print(f'Error: tag "{tag}" already exists')
-        return
+        print(f'Error: tag "{tag}" already exists', file=sys.stderr)
+        sys.exit(1)
 
     write_version(version)
     commit_change(version)

--- a/tag.py
+++ b/tag.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import re
+import subprocess
+
+def check_version_format(version):
+    pattern = re.compile(r'^\d+\.\d+\.\d+$')
+    return pattern.match(version) is not None
+
+def check_tag_exists(tag):
+    try:
+        subprocess.check_output(['git', 'rev-parse', tag], stderr=subprocess.STDOUT)
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+def write_version(version):
+    with open('roc/version.go', 'r') as f:
+        lines = f.readlines()
+
+    with open('roc/version.go', 'w') as f:
+        for line in lines:
+            if line.startswith('var bindingsVersion ='):
+                line = f'var bindingsVersion = "{version}"\n'
+            f.write(line)
+
+def commit_change(version):
+    subprocess.check_call(['git', 'add', 'roc/version.go'])
+    subprocess.check_call(['git', 'commit', '-m', f'Release {version}'])
+
+def create_tag(tag):
+    subprocess.check_call(['git', 'tag', tag])
+
+def push_change(remote, tag):
+    subprocess.check_call(['git', 'push', remote, 'HEAD'])
+    subprocess.check_call(['git', 'push', remote, tag])
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--push', required=False, help='remote to push')
+    parser.add_argument('version', help='version to release')
+    args = parser.parse_args()
+
+    version = args.version
+    remote = args.push
+    tag = f'v{version}'
+
+    if not check_version_format(version):
+        print(f'Error: version "{version}" is not in correct format. Correct format is "x.y.z"')
+        return
+
+    if check_tag_exists(tag):
+        print(f'Error: tag "{tag}" already exists')
+        return
+
+    write_version(version)
+    commit_change(version)
+    create_tag(tag)
+    if remote:
+        push_change(remote, tag)
+    print(f'Successfully released {tag}')
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
#106 

```
➜  roc-go git:(main) ✗ ./tag.py 0.1111
Error: version "0.1111" is not in correct format
➜  roc-go git:(main) ✗ ./tag.py 0.2.1        
Error: tag "v0.2.1" already exists
➜  roc-go git:(main) ✗ ./tag.py --push ortex 0.2.2
[main 51d8c36] Release 0.2.2
 1 file changed, 1 insertion(+), 1 deletion(-)
Enumerating objects: 7, done.
Counting objects: 100% (7/7), done.
Delta compression using up to 10 threads
Compressing objects: 100% (4/4), done.
Writing objects: 100% (4/4), 348 bytes | 348.00 KiB/s, done.
Total 4 (delta 3), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (3/3), completed with 3 local objects.
To github.com:ortex/roc-go.git
   0df41a5..51d8c36  HEAD -> main
Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
To github.com:ortex/roc-go.git
 * [new tag]         v0.2.2 -> v0.2.2
Successfully released v0.2.2
```

result: https://github.com/ortex/roc-go/commit/51d8c36e136d193ccb4310517af2352acc2182de