### PR TITLE
Minor cleanup in tag.py

### DIFF
--- a/tag.py
+++ b/tag.py
@@ -18,14 +18,14 @@ def check_tag_exists(tag):
         return False
 
 def write_version(version):
-    print(f'Updating version in roc/version.go to {version}')
+    print(f'--- Updating version in roc/version.go to {version}')
     version_line = re.compile(r'\bbindingsVersion\s*=\s*".*"')
     with fileinput.FileInput('roc/version.go', inplace=True) as f:
         for line in f:
             print(version_line.sub(f'bindingsVersion = "{version}"', line), end='')
 
 def run_command(args):
-    print(f'Running command: {" ".join(args)}')
+    print(f'--- Running command: {" ".join(args)}')
     subprocess.check_call(args)
 
 def commit_change(version):
@@ -42,17 +42,20 @@ def push_change(remote, tag):
 def main():
     os.chdir(os.path.dirname(os.path.realpath(__file__)))
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--push', required=False, help='remote to push')
-    parser.add_argument('version', help='version to release')
+    parser = argparse.ArgumentParser(description='Create and push tag for new release')
+    parser.add_argument('--push', metavar='REMOTE', required=False,
+                        help='remote to push (e.g. "origin")')
+    parser.add_argument('version', metavar='VERSION',
+                        help='version to release ("N.N.N" or "vN.N.N")')
     args = parser.parse_args()
 
     version = args.version
     if not check_version_format(version):
-        print(f'Error: version "{version}" is not in correct format. Correct format is "x.y.z" or "vx.y.z"', file=sys.stderr)
+        print(f'Error: version "{version}" is not in correct format,'
+              ' expected "N.N.N" or "vN.N.N"', file=sys.stderr)
         sys.exit(1)
 
-    version = version.lstrip("v")
+    version = version.lstrip('v')
     remote = args.push
     tag = f'v{version}'
 
@@ -65,7 +68,7 @@ def main():
     create_tag(tag)
     if remote:
         push_change(remote, tag)
-    print(f'Successfully released {tag}')
+    print(f'--- Successfully released {tag}')
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()


### PR DESCRIPTION
```
./tag.py -h
usage: tag.py [-h] [--push REMOTE] VERSION

Create and push tag for new release

positional arguments:
  VERSION        version to release ("N.N.N" or "vN.N.N")

options:
  -h, --help     show this help message and exit
  --push REMOTE  remote to push (e.g. "origin")
```

```
./tag.py 9.9.1
--- Updating version in roc/version.go to 9.9.1
--- Running command: git add roc/version.go
--- Running command: git commit -m Release 9.9.1
[main a613a14] Release 9.9.1
 1 file changed, 1 insertion(+), 1 deletion(-)
--- Running command: git tag v9.9.1
--- Successfully released v9.9.1
```