### PR TITLE
Fix race in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ else
 gotest := go test
 endif
 
-all: gen build lint testall
+all: gen build lint test_all
 
 gen:
 	cd roc && go generate

--- a/roc/log.go
+++ b/roc/log.go
@@ -244,6 +244,17 @@ func logRoutine() {
 	}
 }
 
+func logDrain() {
+	for {
+		select {
+		case <-loggerChan:
+			continue
+		default:
+			return
+		}
+	}
+}
+
 func init() {
 	SetLogLevel(LogError)
 	SetLoggerFunc(nil)


### PR DESCRIPTION
Tests fail from time to time: https://github.com/roc-streaming/roc-go/actions/runs/14109936756/job/39525713603

It happens because when the test starts, `loggerChan` may contains some messages from previous tests.

Changes:

* add `logDrain()` function to drop all messages from `loggerChan`
* call it in the beginning of every logger test
* relax checks in `TestLog_Write`