### PR TITLE
updated golandci-lint install link

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -4,7 +4,7 @@
 
 Additional dependencies needed for development:
 
-* [golangci-lint](https://golangci-lint.run/usage/install/#local-installation)
+* [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation)
 
 * [stringer](https://github.com/golang/tools)
 


### PR DESCRIPTION
Simple update, the HACKING.MD was out of date, the install url location has changed